### PR TITLE
Fix matrix corruption in VoxelMap compatibility mixin

### DIFF
--- a/mod/src/main/java/page/langeweile/longview/mixin/compat/voxelmap/VMCOPMBMixin.java
+++ b/mod/src/main/java/page/langeweile/longview/mixin/compat/voxelmap/VMCOPMBMixin.java
@@ -21,7 +21,7 @@ public abstract class VMCOPMBMixin {
 	)
 	private Matrix4f invertOrthogonalMatrixZ(Matrix4f instance, float left, float right, float bottom, float top, float zNear, float zFar, Operation<Matrix4f> original) {
 		return LongviewImpl.isZReversed()
-			? instance.ortho(left, right, bottom, top, zFar, zNear, RenderSystem.getDevice().isZZeroToOne())
-			: instance.ortho(left, right, bottom, top, zNear, zFar, RenderSystem.getDevice().isZZeroToOne());
+			? instance.setOrtho(left, right, bottom, top, zFar, zNear, RenderSystem.getDevice().isZZeroToOne())
+			: instance.setOrtho(left, right, bottom, top, zNear, zFar, RenderSystem.getDevice().isZZeroToOne());
 	}
 }


### PR DESCRIPTION
Fixes a matrix calculation flaw in `VMCOPMBMixin` where `Matrix4f#ortho` was called instead of `Matrix4f#setOrtho`. This was causing matrix post-multiplication instead of setting the projection matrix, leading to corrupted rendered output for VoxelMap.